### PR TITLE
feat: A starting point for using Docker Compose (and uv)

### DIFF
--- a/Dockerfile.uv
+++ b/Dockerfile.uv
@@ -1,0 +1,54 @@
+#   Step 1
+FROM python:3.13.9-slim-bookworm AS python-base
+
+ENV PYTHONUNBUFFERED=1 \
+    # prevents python creating .pyc files
+    PYTHONDONTWRITEBYTECODE=1
+
+#   Step 2: Python dependencies
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder-base
+# install system packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  curl \
+  libffi-dev \
+  python3-cffi \
+  python3-dev \
+  python3-setuptools \
+  python3-wheel \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV WORKDIR=/app
+WORKDIR $WORKDIR
+# install python deps
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev
+
+#   Step 3: Final composition
+FROM python-base AS final
+ENV PATH="/app/.venv/bin:$PATH"
+
+ENV WORKDIR=/app
+WORKDIR $WORKDIR
+
+# From: https://hynek.me/articles/docker-uv/
+RUN <<EOT
+groupadd -r app
+useradd -r -d /app -g app -N app
+chown app:app /app
+EOT
+
+USER app
+
+STOPSIGNAL SIGINT
+
+COPY --chown=app:app --from=builder-base /app/.venv /app/.venv
+COPY --chown=app:app app app
+
+COPY --chown=app:app --from=ghcr.io/astral-sh/uv:latest /uv /bin/
+
+CMD ["/bin/bash", "-c", "uv run fastapi run app/main.py --host 0.0.0.0 --port $PORT --workers 1"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,32 @@
+# Note: this is a starting point for a local setup.
+#
+# It's possible to add more services and even run FastAPI in dev mode combined with
+# Docker Compose watch, see - https://docs.docker.com/compose/how-tos/file-watch/
+#
+# Should it ever be used for a production environment the POSTGRES_PASSWORD must not be hard
+# coded like this.
+services:
+  postgres:
+    # Adapt to whatever Postgres version is needed
+    # If <18 make sure to read the docs - https://hub.docker.com/_/postgres -
+    # since the storage path for PGDATA changed in v18.
+    image: postgres:18-bookworm
+    ports:
+      - "5432:5432" # Exposes the service on localhost
+    environment:
+      POSTGRES_USER: cag4
+      POSTGRES_PASSWORD: cag4
+      PGDATA: /var/lib/postgresql/18/docker
+    volumes:
+      - postgresdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "cag4"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+    logging:
+      # Disable logging, if removed make sure logrotation is set up.
+      driver: none
+
+volumes:
+  postgresdata: # A named Docker volume for persisting data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,27 @@
+[project]
+name = "cag4-backend"
+version = "0.1.4"
+description = ""
+authors = []
+readme = "app/README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "alembic>=1.17.0",
+    "bcrypt==4.3.0",
+    "fastapi[standard]>=0.119.0",
+    "passlib[bcrypt]>=1.7.4",
+    "psycopg[binary]>=3.2.10",
+    "pydantic>=2.12.2",
+    "pydantic-settings>=2.11.0",
+    "pyjwt>=2.10.1",
+]
+
+[dependency-groups]
+dev = [
+    "alembic>=1.17.0",
+    "python-dotenv>=1.1.1",
+]
+
 # line length settings for black
 [tool.black]
 line-length = 150


### PR DESCRIPTION
I'll let @Rappich explain why this ends up here :)

The changes to `pyproject.toml` would let you use [uv](https://docs.astral.sh/uv/). 

## An uv workflow could look like this

1. Add direct dependencies (writes to pyproject.toml)

```bash
# You can normally do passlib[bcrypt] but a change in bcrypt==5.0.0 breaks with passlib.
# Hence the pinned bcrypt version.
uv add alembic passlib pydantic bcrypt==4.3.0 pydantic-settings pyjwt "psycopg[binary]" "fastapi[standard]"
```

**Kind of optional**: To let uv decide, from the direct dependencies added above, what's necessary if a `requirements.txt` file is needed:

```bash
uv pip compile -o requirements.txt pyproject.toml
```

But if uv is used everywhere the `requirements.txt` file can be omitted. uv operates on its own `uv.lock` file. Please see an example of a uv only workflow in `Dockerfile.uv`.

2. Add development dependencies (things that are necessary when building the app)

```bash
uv add --dev alembic flake8 black pytest pytest-cov pytest-asyncio detect-secrets httpx
# Tip: ruff is a modern solution that does what both black and flake8 does.
```

## Using Docker Compose

A first iteration on a Docker Compose setup can be found in `compose.yaml`. Progressing from there could lead to https://github.com/Chas-Advance-Grupp-4/backend/issues/56.

Start the PostgreSQL database with `docker compose up`

## Combining uv and Docker Compose

1. Make sure Postgres container is running (see instructions above)
2. Run Alembic migrations: `uv run alembic upgrade head`
   **Important**: make sure the username/password in the `.env` file matches what's in the `compose.yaml` file.
   Like this:

   ```bash filename=".env"
    DATABASE_URL=postgresql+psycopg://cag4:cag4@localhost:5432/cag4
   ```

3. Run the service: `uv run fastapi dev app/main.py`
