### PR TITLE
feat: 128-11.1.12-create-endpoint-for-embedded

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-# Pull Reqest for develop and main
-
-- [ ] I Have uppdated the VERSION file with correct version number for this release 
-- [ ] 1.1 1.2 2.1 ... for develop
-- [ ] 2.0 3.0 ... for main
-- [ ] I made shore I entered the right format for our next release

--- a/app/api/v1/endpoints/control_unit.py
+++ b/app/api/v1/endpoints/control_unit.py
@@ -4,11 +4,13 @@ from sqlalchemy.exc import SQLAlchemyError
 from uuid import UUID
 from app.dependencies import get_db
 from app.dependencies import get_current_control_unit
+from app.models.shipment_model import Shipment
 from app.api.v1.schemas.control_unit_schema import (
     DeviceData,
     ControlUnitDataCreate,
     ControlUnitDataUpdate,
     ControlUnitDataRead,
+    ControlUnitStatusRequest,
 )
 from app.services.control_unit_service import (
     save_device_data,
@@ -18,6 +20,11 @@ from app.services.control_unit_service import (
     update_control_unit_data,
     delete_control_unit_data,
 )
+
+CONTROL_UNIT_SENSOR_ID_MAP = {
+    UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479"): UUID("550e8400-e29b-41d4-a716-446655440000")
+    # Control Unit Id who is making the request : Sensor Unit Id assigned to the Control Unit
+}
 
 router = APIRouter()
 
@@ -112,6 +119,55 @@ def receive_device_data(
 
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Unexpected error: {str(e)}")
+
+
+@router.post("/status", summary="Return sensor unit and shipment status for given control unit.")
+def control_unit_status(
+    request: ControlUnitStatusRequest, db: Session = Depends(get_db), current_unit: dict = Depends(get_current_control_unit)
+):
+    """
+    Retrieve the sensor unit ID and shipment status for a given control unit.
+
+    Args:
+        control_unit_id (UUID): The unique ID of the control unit.
+        db (Session): Database session dependency.
+        current_unit (dict): The current control unit info from the token.
+    Returns:
+        dict: The sensor unit ID and shipment status, if found and status is in_transit or delivered.
+        None: If shipment status is not in_transit or delivered.
+    Raises:
+        HTTPException 400: If control unit ID in token is invalid.
+        HTTPException 403: If control unit ID doesn't match token.
+        HTTPException 404: If control unit or shipment not found.
+    """
+    try:
+        token_unit_id = UUID(current_unit["unit_id"])
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid control unit ID in token",
+        )
+
+    control_unit_id = request.control_unit_id
+
+    if control_unit_id != token_unit_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Could not validate control_unit_id",
+        )
+
+    if control_unit_id not in CONTROL_UNIT_SENSOR_ID_MAP:
+        raise HTTPException(status_code=404, detail="control_unit_id not found")
+
+    sensor_unit_id = CONTROL_UNIT_SENSOR_ID_MAP[control_unit_id]
+    shipment = db.query(Shipment).filter(Shipment.sensor_unit_id == sensor_unit_id).first()
+    if not shipment:
+        raise HTTPException(status_code=404, detail="No shipment found for the sensor_unit_id")
+
+    if shipment.status.value not in ["in_transit", "delivered"]:
+        return None
+
+    return {"sensor_unit_id": str(shipment.sensor_unit_id), "status": shipment.status.value}
 
 
 @router.get(

--- a/app/api/v1/schemas/control_unit_schema.py
+++ b/app/api/v1/schemas/control_unit_schema.py
@@ -124,3 +124,14 @@ class DeviceData(BaseModel):
 
     control_unit_id: UUID
     timestamp_groups: List[TimestampGroup] = []
+
+
+class ControlUnitStatusRequest(BaseModel):
+    """
+    Represents the control_unit_id request for status checking.
+
+    Attributes:
+        control_unit_id (UUID): The unique ID of the control unit.
+    """
+
+    control_unit_id: UUID

--- a/app/utils/JWT.py
+++ b/app/utils/JWT.py
@@ -44,7 +44,7 @@ def decode_access_token(token: str) -> dict | None:
         dict | None: The decoded payload if valid; None if the token is invalid or expired.
     """
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM.strip()])
         return payload
     except PyJWTError:
         return None
@@ -61,7 +61,7 @@ def decode_control_unit_secret_key(token: str) -> dict | None:
         dict | None: The decoded payload if valid; None if the token is invalid or expired.
     """
     try:
-        payload = jwt.decode(token, settings.CONTROL_UNIT_SECRET_KEY, algorithms=[settings.ALGORITHM])
+        payload = jwt.decode(token, settings.CONTROL_UNIT_SECRET_KEY, algorithms=[settings.ALGORITHM.strip()])
         return payload
     except PyJWTError:
         return None

--- a/app/utils/generate_mock_token.py
+++ b/app/utils/generate_mock_token.py
@@ -1,13 +1,17 @@
 import os
 import jwt
 from datetime import datetime, timedelta, timezone
-import uuid
+
+# import uuid
 
 CONTROL_UNIT_SECRET_KEY = os.getenv("CONTROL_UNIT_SECRET_KEY")
 ALGORITHM = "HS256"
 
-mock_unit_id = str(uuid.uuid4())
-# mock_unit_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+# Choose hardcoded Id if you need the specific one, otherwise generate the other outcommented one.
+# Remember to delete comment sign for uuid!
+
+# mock_unit_id = str(uuid.uuid4())
+mock_unit_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 payload = {"unit_id": mock_unit_id, "exp": datetime.now(timezone.utc) + timedelta(minutes=30)}
 
 token = jwt.encode(payload, CONTROL_UNIT_SECRET_KEY, algorithm=ALGORITHM)

--- a/app/utils/generate_mock_token.py
+++ b/app/utils/generate_mock_token.py
@@ -7,7 +7,7 @@ CONTROL_UNIT_SECRET_KEY = os.getenv("CONTROL_UNIT_SECRET_KEY")
 ALGORITHM = "HS256"
 
 mock_unit_id = str(uuid.uuid4())
-
+# mock_unit_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 payload = {"unit_id": mock_unit_id, "exp": datetime.now(timezone.utc) + timedelta(minutes=30)}
 
 token = jwt.encode(payload, CONTROL_UNIT_SECRET_KEY, algorithm=ALGORITHM)

--- a/tests/integration/test_controlunit_endpoints.py
+++ b/tests/integration/test_controlunit_endpoints.py
@@ -8,6 +8,9 @@ from app.config.settings import settings
 
 client = TestClient(app)
 
+CONTROL_UNIT_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+SENSOR_UNIT_ID = "550e8400-e29b-41d4-a716-446655440000"
+
 # -------------------------
 # Fixtures
 # -------------------------
@@ -20,7 +23,11 @@ def control_unit_token_and_id():
         "unit_id": unit_id,
         "exp": datetime.now(timezone.utc) + timedelta(minutes=30),
     }
-    token = jwt.encode(payload, settings.CONTROL_UNIT_SECRET_KEY, algorithm=settings.ALGORITHM)
+    token = jwt.encode(
+        payload,
+        settings.CONTROL_UNIT_SECRET_KEY,
+        algorithm=settings.ALGORITHM
+    )
     return token, unit_id
 
 
@@ -65,7 +72,7 @@ def device_data_payload(control_unit_token_and_id):
     """
     _, unit_id = control_unit_token_and_id
     return {
-        "control_unit_id": unit_id,  
+        "control_unit_id": unit_id,
         "timestamp_groups": [
             {
                 "timestamp": int(datetime.now(timezone.utc).timestamp()),
@@ -78,9 +85,103 @@ def device_data_payload(control_unit_token_and_id):
     }
 
 
+@pytest.fixture
+def control_unit_token_and_id_hardcoded():
+    """
+    Provides a JWT token and hardcoded control_unit_id for testing.
+    """
+    unit_id = CONTROL_UNIT_ID
+    payload = {
+        "unit_id": unit_id,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=30),
+    }
+    token = jwt.encode(payload, settings.CONTROL_UNIT_SECRET_KEY, algorithm=settings.ALGORITHM)
+    return token, unit_id
+
+
+@pytest.fixture
+def shipment_payload(admin_headers_fixture):
+    """
+    Provides a shipment payload for testing. Updates the created shipment to link a sensor unit.
+    """
+    payload = {
+        "shipment_number": f"Package-{uuid4()}",
+        "sender_id": str(uuid4()),
+        "receiver_id": str(uuid4()),
+        "driver_id": None,
+        "status": "in_transit",
+        "min_temp": -15,
+        "max_temp": 20,
+        "min_humidity": 20,
+        "max_humidity": 80,
+        "delivery_address": "Delivery 1, 34456 Test City",
+        "pickup_address": "Pickup 1, 34456 Test City"
+    }
+    resp = client.post("/api/v1/shipments/", json=payload, headers=admin_headers_fixture)
+    assert resp.status_code == 200
+    shipment = resp.json()
+    update_payload = {"sensor_unit_id": SENSOR_UNIT_ID}
+    resp = client.patch(f"/api/v1/shipments/update-all/{shipment['id']}", json=update_payload, headers=admin_headers_fixture)
+    assert resp.status_code == 200
+    shipment = resp.json()
+    assert shipment["sensor_unit_id"] == SENSOR_UNIT_ID
+    return shipment
+
+
 # -------------------------
 # Integration tests
 # -------------------------
+
+
+def test_control_unit_status(control_unit_token_and_id_hardcoded, shipment_payload):
+    """
+    Purpose: Test that /control-unit/status returns the correct sensor_unit_id and status for a shipment.
+    Scenario: A shipment with a linked sensor unit is connected to control_unit which has a valid token.
+    Expected: Response 200 with correct sensor_unit_id and status.
+    """
+    token, _ = control_unit_token_and_id_hardcoded
+    headers = {"Authorization": f"Bearer {token}"}
+
+    status_resp = client.post(
+        "/api/v1/control-unit/status",
+        json={"control_unit_id": CONTROL_UNIT_ID},
+        headers=headers
+    )
+    assert status_resp.status_code == 200
+    data = status_resp.json()
+    assert data["sensor_unit_id"] == SENSOR_UNIT_ID
+    assert data["status"] == "in_transit"
+
+
+def test_control_unit_status_wrong_token():
+    """
+    Purpose: Test that /control-unit/status returns 401 for an invalid token.
+    Scenario: An invalid JWT token is provided.
+    Expected: Response 401 Unauthorized.
+    """
+    headers = {"Authorization": "Bearer INVALIDTOKEN"}
+    resp = client.post(
+        "/api/v1/control-unit/status",
+        json={"control_unit_id": CONTROL_UNIT_ID},
+        headers=headers
+    )
+    assert resp.status_code == 401
+
+
+def test_control_unit_status_wrong_control_unit_id(control_unit_token_and_id):
+    """
+    Purpose: Test that /control-unit/status returns 403 for a control_unit_id not matching the token.
+    Scenario: A valid JWT token is provided but with a mismatched control_unit_id.
+    Expected: Response 403 Forbidden.
+    """
+    token, _ = control_unit_token_and_id
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.post(
+        "/api/v1/control-unit/status",
+        json={"control_unit_id": "00000000-0000-0000-0000-000000000000"},
+        headers=headers
+    )
+    assert resp.status_code == 403
 
 
 def test_post_single_reading(single_reading_payload, control_unit_token_and_id):

--- a/tests/unit/test_schemas_controlunit.py
+++ b/tests/unit/test_schemas_controlunit.py
@@ -5,7 +5,6 @@ from app.api.v1.schemas.control_unit_schema import (
     ControlUnitDataBase,
     ControlUnitDataCreate,
     ControlUnitDataUpdate,
-    ControlUnitDataRead,
     DeviceData,
     TimestampGroup,
     SensorUnitReading,
@@ -24,7 +23,11 @@ def test_control_unit_base_valid():
     Expected: Object created successfully; humidity and temperature values match input.
     """
     data = ControlUnitDataBase(
-        sensor_unit_id=uuid4(), control_unit_id=uuid4(), humidity={"value": 50}, temperature={"value": 25}, timestamp=datetime.now()
+        sensor_unit_id=uuid4(),
+        control_unit_id=uuid4(),
+        humidity={"value": 50},
+        temperature={"value": 25},
+        timestamp=datetime.now()
     )
     assert data.humidity["value"] == 50
     assert data.temperature["value"] == 25
@@ -37,7 +40,11 @@ def test_control_unit_base_invalid_empty_dict():
     Expected: Pydantic ValidationError is raised.
     """
     with pytest.raises(ValidationError):
-        ControlUnitDataBase(sensor_unit_id=uuid4(), control_unit_id=uuid4(), humidity={}, temperature={})
+        ControlUnitDataBase(
+            sensor_unit_id=uuid4(),
+            control_unit_id=uuid4(),
+            humidity={}, temperature={}
+        )
 
 
 def test_control_unit_create():
@@ -46,7 +53,12 @@ def test_control_unit_create():
     Scenario: Provide valid sensor_unit_id, control_unit_id, humidity, temperature.
     Expected: Object created successfully; humidity and temperature values match input.
     """
-    create_data = ControlUnitDataCreate(sensor_unit_id=uuid4(), control_unit_id=uuid4(), humidity={"value": 55}, temperature={"value": 22})
+    create_data = ControlUnitDataCreate(
+        sensor_unit_id=uuid4(),
+        control_unit_id=uuid4(),
+        humidity={"value": 55},
+        temperature={"value": 22}
+    )
     assert create_data.humidity["value"] == 55
     assert create_data.temperature["value"] == 22
 


### PR DESCRIPTION
Added a endpoint where embedded can post control unit id and get back connected sensor and status for the connected sensor if status is in_transit or delivered on the shipment. 
Added tests for that endpoint
Added schema to validate correct request form
Updated/added documentation for endpoint
Added hardcoded connection between control_unit_id and sensor_unit_id
Added hardcoded control_unit_id to create valid token for that unit. 
Deleted unnessesary PR template